### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 modem-cmd (Python)
 ==================
-.. image:: https://pypip.in/version/modem-cmd/badge.svg
+.. image:: https://img.shields.io/pypi/v/modem-cmd.svg
     :target: https://pypi.python.org/pypi/modem-cmd/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20modem-cmd))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `modem-cmd`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.